### PR TITLE
Upgrade to videosdk 4.0.1 and handle the new PubSub exceptions

### DIFF
--- a/lib/screens/conference-call/conference_meeting_screen.dart
+++ b/lib/screens/conference-call/conference_meeting_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:developer';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
@@ -452,6 +453,9 @@ class _ConferenceMeetingScreenState extends State<ConferenceMeetingScreen> {
           }
         }
       }
+    }).catchError((Object e) {
+      log("Subscribe failed: $e");
+      return PubSubMessages(messages: const []);
     });
   }
 

--- a/lib/screens/one-to-one/one_to_one_meeting_screen.dart
+++ b/lib/screens/one-to-one/one_to_one_meeting_screen.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:developer';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
@@ -447,6 +448,9 @@ class _OneToOneMeetingScreenState extends State<OneToOneMeetingScreen> {
           }
         }
       }
+    }).catchError((Object e) {
+      log("Subscribe failed: $e");
+      return PubSubMessages(messages: const []);
     });
   }
 

--- a/lib/widgets/common/chat/chat_view.dart
+++ b/lib/widgets/common/chat/chat_view.dart
@@ -1,3 +1,5 @@
+import 'dart:developer';
+
 import 'package:flutter/material.dart';
 import 'package:videosdk/videosdk.dart';
 import 'package:videosdk_flutter_example/constants/colors.dart';
@@ -29,7 +31,8 @@ class _ChatViewState extends State<ChatView> {
     // Subscribing 'CHAT' Topic
     widget.meeting.pubSub
         .subscribe("CHAT", messageHandler)
-        .then((value) => setState((() => messages = value)));
+        .then((value) => setState((() => messages = value)))
+        .catchError((Object e) => log("Subscribe failed: $e"));
   }
 
   @override
@@ -125,7 +128,9 @@ class _ChatViewState extends State<ChatView> {
                                 msgTextController.text,
                                 const PubSubPublishOptions(persist: true),
                               )
-                              .then((value) => msgTextController.clear()),
+                              .then((value) => msgTextController.clear())
+                              .catchError(
+                                  (Object e) => log("Publish failed: $e")),
                       child: Container(
                           padding: const EdgeInsets.symmetric(
                               horizontal: 8, vertical: 8),
@@ -154,7 +159,9 @@ class _ChatViewState extends State<ChatView> {
 
   @override
   void dispose() {
-    widget.meeting.pubSub.unsubscribe("CHAT", messageHandler);
+    widget.meeting.pubSub
+        .unsubscribe("CHAT", messageHandler)
+        .catchError((Object e) => log("Unsubscribe failed: $e"));
     super.dispose();
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  videosdk: ^3.12.1
+  videosdk: ^4.0.1
   permission_handler: ^12.0.3 # 13.x needs compileSdk 37 (AGP 8.13+)
   http: ^1.1.0
   flutter_dotenv: ^5.0.2


### PR DESCRIPTION
- Bump videosdk dependency from ^3.12.1 to ^4.0.1.
- PubSub publish(), subscribe() and unsubscribe() throw a PubSubException in 4.x instead of failing silently, so every call site now handles the rejection: chat view subscribe/publish/unsubscribe, and the CHAT snackbar subscription on both meeting screens.
- subscribe() returns Future<PubSubMessages>, so its catchError handler returns an empty PubSubMessages; dispose() cannot await, so the unsubscribe teardown uses catchError as well.
- No optional 4.x APIs adopted: with no options passed, subscribe() still resolves with the complete history as in 3.x.